### PR TITLE
Add multi-step onboarding flow

### DIFF
--- a/luna/src/pages/App.jsx
+++ b/luna/src/pages/App.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import LandingPage from './LandingPage';
-import Onboarding from './Onboarding';
 import Journal from './Journal';
+import Step1 from './onboarding/Step1';
+import Step2 from './onboarding/Step2';
+import Step3 from './onboarding/Step3';
+import Step4 from './onboarding/Step4';
 
 export default function App() {
   return (
     <Routes>
       <Route path="/" element={<LandingPage />} />
-      <Route path="/onboarding" element={<Onboarding />} />
       <Route path="/journal" element={<Journal />} />
+      <Route path="/onboarding/step-1" element={<Step1 />} />
+      <Route path="/onboarding/step-2" element={<Step2 />} />
+      <Route path="/onboarding/step-3" element={<Step3 />} />
+      <Route path="/onboarding/step-4" element={<Step4 />} />
     </Routes>
   );
 }

--- a/luna/src/pages/onboarding/Step1.jsx
+++ b/luna/src/pages/onboarding/Step1.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Step1() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 text-gray-700 font-sans p-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-xl normal-case">what's on your mind today?</h1>
+        <textarea
+          rows="5"
+          className="w-full p-3 border border-gray-300 rounded-md bg-white text-gray-700 focus:outline-none"
+        />
+        <Link
+          to="/onboarding/step-2"
+          className="inline-block px-4 py-2 bg-gray-200 text-gray-700 rounded-md"
+        >
+          next
+        </Link>
+        <div className="flex justify-center space-x-2 pt-4">
+          <span className="h-2 w-2 rounded-full bg-gray-700"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/luna/src/pages/onboarding/Step2.jsx
+++ b/luna/src/pages/onboarding/Step2.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const emotions = ['calm', 'anxious', 'tired', 'ok'];
+
+export default function Step2() {
+  const [selected, setSelected] = useState('');
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 text-gray-700 font-sans p-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-xl normal-case">how are you feeling right now?</h1>
+        <div className="flex flex-wrap justify-center gap-2">
+          {emotions.map((emotion) => (
+            <button
+              key={emotion}
+              type="button"
+              onClick={() => setSelected(emotion)}
+              className={`px-4 py-2 border rounded-full ${selected === emotion ? 'bg-gray-200' : 'bg-white'}`}
+            >
+              {emotion}
+            </button>
+          ))}
+        </div>
+        <Link
+          to="/onboarding/step-3"
+          className="inline-block px-4 py-2 bg-gray-200 text-gray-700 rounded-md"
+        >
+          next
+        </Link>
+        <div className="flex justify-center space-x-2 pt-4">
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-700"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/luna/src/pages/onboarding/Step3.jsx
+++ b/luna/src/pages/onboarding/Step3.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Step3() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 text-gray-700 font-sans p-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-xl normal-case">is there something you'd like to reflect on?</h1>
+        <textarea
+          rows="5"
+          className="w-full p-3 border border-gray-300 rounded-md bg-white text-gray-700 focus:outline-none"
+        />
+        <Link
+          to="/onboarding/step-4"
+          className="inline-block px-4 py-2 bg-gray-200 text-gray-700 rounded-md"
+        >
+          next
+        </Link>
+        <div className="flex justify-center space-x-2 pt-4">
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-700"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/luna/src/pages/onboarding/Step4.jsx
+++ b/luna/src/pages/onboarding/Step4.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Step4() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 text-gray-700 font-sans p-4">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-xl normal-case">you're doing enough. ready to begin?</h1>
+        <Link
+          to="/journal"
+          className="inline-block px-4 py-2 bg-gray-200 text-gray-700 rounded-md"
+        >
+          start journaling
+        </Link>
+        <div className="flex justify-center space-x-2 pt-4">
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-300"></span>
+          <span className="h-2 w-2 rounded-full bg-gray-700"></span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add four-step onboarding journey with calming prompts and navigation
- include emotion selection in step two and journaling start in final step
- wire new onboarding steps into router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcfb5296883238d1e855cb79ebced